### PR TITLE
fix: Dockerfile uses now the mcr.microsoft.com/dotnet/sdk:7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 COPY ./ /app
 


### PR DESCRIPTION
Dockerfile uses now the mcr.microsoft.com/dotnet/sdk:7.0 instead the 6.0 version. I didn't got the docker container built with the 6.0 version of the sdk container and it complained about the version mismatch. I guess that was a typo or similar and it works on your machine because you have installed version 6.0 of dotnet.